### PR TITLE
POC for zarr support - DO NOT MERGE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,11 @@ with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'dask[array] == 2021.2.0',
     'donfig >= 0.4.0',
-    'numpy >= 1.14.0, <= 1.19.5',  # breakage in newer numpy + numerical errors
     'numba >= 0.43.0',
     'scipy >= 1.2.0',
     'threadpoolctl >= 1.0.0',
-    'dask-ms == 0.2.6',
-    'zarr >= 2.3.1'
+    'dask-ms[xarray,zarr,s3]'
 ]
 
 extras_require = {'testing': ['pytest',

--- a/tricolour/mask.py
+++ b/tricolour/mask.py
@@ -60,7 +60,7 @@ def load_mask(filename, dilate):
     # Load mask
     mask = np.load(filename)
 
-    if mask.dtype[0] != np.bool or mask.dtype[1] != np.float64:
+    if mask.dtype[0] != np.bool_ or mask.dtype[1] != np.float64:
         raise ValueError("Mask %s is not a valid static mask "
                          "with labelled channel axis "
                          "[dtype == (bool, float64)]" % filename)

--- a/tricolour/packing.py
+++ b/tricolour/packing.py
@@ -90,7 +90,7 @@ def _create_window_dask(name, ntime, nchan, nbl, ncorr, token,
 
     graph = HighLevelGraph.from_collections(collection_name, layers, ())
     chunks = ((0,),)  # One chunk containing single zarr array object
-    return da.Array(graph, collection_name, chunks, dtype=np.object)
+    return da.Array(graph, collection_name, chunks, dtype=object)
 
 
 def create_vis_windows(ntime, nchan, nbl, ncorr, token,
@@ -343,7 +343,7 @@ def pack_data(time_inv, ubl,
                            flags, ("row", "chan", "corr"),
                            vis_win_obj, ("windim",),
                            flag_win_obj, ("windim",),
-                           dtype=np.bool)
+                           dtype=np.bool_)
 
     # Expose visibility data at it's full resolution
     vis_windows = da.blockwise(_packed_windows, _WINDOW_SCHEMA,

--- a/tricolour/tests/test_flagging_additional.py
+++ b/tricolour/tests/test_flagging_additional.py
@@ -131,7 +131,7 @@ def test_apply_static_mask(wsrt_ants, unique_baselines,
                                   accumulation_mode="or")
 
     # Check that first mask's flags are applied
-    chan_sel = np.zeros(chan_freqs.shape[0], dtype=np.bool)
+    chan_sel = np.zeros(chan_freqs.shape[0], dtype=np.bool_)
     chan_sel[[2, 10]] = True
 
     assert np.all(new_flags[:, :, :, chan_sel] == 1)
@@ -144,7 +144,7 @@ def test_apply_static_mask(wsrt_ants, unique_baselines,
                                   accumulation_mode="or")
 
     # Check that both mask's flags have been applied
-    chan_sel = np.zeros(chan_freqs.shape[0], dtype=np.bool)
+    chan_sel = np.zeros(chan_freqs.shape[0], dtype=np.bool_)
     chan_sel[[2, 10, 4, 11, 5]] = True
 
     assert np.all(new_flags[:, :, :, chan_sel] == 1)
@@ -157,7 +157,7 @@ def test_apply_static_mask(wsrt_ants, unique_baselines,
                                   accumulation_mode="override")
 
     # Check that only last mask's flags applied
-    chan_sel = np.zeros(chan_freqs.shape[0], dtype=np.bool)
+    chan_sel = np.zeros(chan_freqs.shape[0], dtype=np.bool_)
     chan_sel[[4, 11, 5]] = True
 
     assert np.all(new_flags[:, :, :, chan_sel] == 1)
@@ -176,7 +176,7 @@ def test_apply_static_mask(wsrt_ants, unique_baselines,
                                   uvrange=uvrange)
 
     # Check that both mask's flags have been applied
-    chan_sel = np.zeros(chan_freqs.shape[0], dtype=np.bool)
+    chan_sel = np.zeros(chan_freqs.shape[0], dtype=np.bool_)
     chan_sel[[2, 10, 4, 11, 5]] = True
 
     # Select baselines based on the uvrange

--- a/tricolour/window_statistics.py
+++ b/tricolour/window_statistics.py
@@ -123,7 +123,7 @@ def window_stats(flag_window, ubls, chan_freqs,
                          field_name, None,
                          ddid, None,
                          nchanbins, None,
-                         meta=np.empty((0,), dtype=np.object))
+                         meta=np.empty((0,), dtype=object))
 
     # Create an empty stats object if the user hasn't supplied one
     if prev_stats is None:
@@ -131,13 +131,13 @@ def window_stats(flag_window, ubls, chan_freqs,
             return WindowStatistics(nchanbins)
 
         prev_stats = da.blockwise(_window_stat_creator, (),
-                                  meta=np.empty((), dtype=np.object))
+                                  meta=np.empty((), dtype=object))
 
     # Combine per-baseline stats into a single stats object
     return da.blockwise(_combine_baseline_window_stats, (),
                         stats, ("bl",),
                         prev_stats, (),
-                        meta=np.empty((), dtype=np.object))
+                        meta=np.empty((), dtype=object))
 
 
 def _combine_window_stats(*args):
@@ -167,7 +167,7 @@ def combine_window_stats(window_stats):
     args = (v for ws in window_stats for v in (ws, ()))
 
     return da.blockwise(_combine_window_stats, (),
-                        *args, dtype=np.object)
+                        *args, dtype=object)
 
 
 class WindowStatistics(object):


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API


<details>
<summary> Howto run test cases and lint the code base </summary>

```bash
$ py.test --flake8 -v -s tricolour
```

If you encounter flake8 failures, a quick way to correct
this is to run `autopep8` and `flake8` again.

```bash
$ pip install -U autopep8
$ autopep8 -r -i tricolour
$ flake8 tricolour
```
</details>


<details>
<summary> Howto build the documentation </summary>

To build the docs locally:

```bash
$ pip install -r requirements.readthedocs.txt
$ cd docs
$ READTHEDOCS=True make html
```

</details>

This PR replaces `xds_from_ms`, `xds_from_table` and `xds_to_table` with their `xds_to/from_storage_*` equivalents. As part of this change I had to unpin basically all the dependencies i.e. this is not safe to merge. The reason for this change is to establish whether we can use Tricolour on AWS using zarr backed data in s3.

This runs through on a toy example on my laptop but there are still some sharp edges. The most important of these is that once a dataset has been converted to zarr, we no longer have the ability to reorder it via TAQL i.e. for now we will assume that any conversion will result in time-ordered data. This could be improved but shouldn't be necessary for POC experiments. 

